### PR TITLE
Added podspec for Nessie SDK

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 Capital One
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Nessie.podspec
+++ b/Nessie.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name             = 'Nessie'
+  s.version          = '0.1.0'
+  s.summary          = 'Capital One Nessie API SDK written in Swift.'
+  s.description      = <<-DESC
+Capital One Nessie API SDK written in Swift, using SwiftyJSON for JSON parsing. Use this Cocoapod to quickly interface with the Capital One Nessie API.
+                       DESC
+  s.homepage         = 'https://github.com/nessieisreal/nessie-ios-sdk-swift'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'Jason Ji' => 'jason.ji@capitalone.com' }
+  s.source           = { :git => 'https://github.com/nessieisreal/nessie-ios-sdk-swift.git', :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/hacknessie'
+
+  s.ios.deployment_target = '9.0'
+
+  s.source_files = 'Nessie-iOS-Wrapper/**/*'
+  s.dependency 'SwiftyJSON', '~> 3.1'
+end

--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@
 ##Synopsis
 Capital One Nessie API SDK written in Swift, using SwiftyJSON for JSON parsing. This SDK can be easily embedded in an iOS project.
 
-##Installation
+##Cocoapods Installation
+1. In your own project, simply include `pod 'Nessie'` in your Podfile and install.
+2. In your Info.plist file, include the dictionary key `NSAppTransportSecurity` and a boolean key `NSAllowsArbitraryLoads` set to YES - see [here](http://useyourloaf.com/blog/app-transport-security/) for details.
+3. Before making any Nessie API calls, set your API Key in `NSEClient.swift` by calling `NSEClient.sharedInstance.setKey("YOUR_KEY_HERE")`. One easy place to do this is in the App Delegate.
+
+##Manual Installation
 1. Download the entire SDK directory.
 2. Open the `Nessie-iOS-Wrapper.xcworkspace` file.
 3. Set your API Key in `NSEClient.swift` where `private var key = ""`


### PR DESCRIPTION
Hey Nessie team,

I've got a PR here that Cocoapod-izes Nessie. I tested this locally and it seems to work (Cocoapods lets you pod-install local pods on your own filesystem), but to actually get it into the real Cocoapods master repo (and thus have it accessible to the world) the following steps have to be done:
1. Accept this PR, merge into master.
2. Tag master with version `0.1.0`, push tags to GitHub
3. Follow [these instructions](https://guides.cocoapods.org/making/getting-setup-with-trunk) or just have me do it - basically pushing the podspec to Cocoapods master repo.

I arbitrarily picked the MIT license because Cocoapods requires a license, but feel free to tweak. Also feel free to change the author of the podspec (it defaulted to me and I don't know who is "in charge" of this SDK, but I'm fine with letting it be whoever).