### PR TITLE
Support Loans

### DIFF
--- a/Nessie-iOS-Wrapper.xcodeproj/project.pbxproj
+++ b/Nessie-iOS-Wrapper.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1D58F258CB981762E988BC09 /* Pods_Nessie_iOS_WrapperTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 047FB39A476B2A2254D31988 /* Pods_Nessie_iOS_WrapperTests.framework */; };
+		1F1CF43B1E3FD0E3009059EB /* Loan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1CF43A1E3FD0E3009059EB /* Loan.swift */; };
+		1F1CF43E1E3FD8F7009059EB /* NSEFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E4A7E1B0BD6EF0076A6D0 /* NSEFunctionalTests.swift */; };
 		4BE174F505915450ACE71C26 /* Pods_NessieTestProj.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9374CA486108DBF4C71F232F /* Pods_NessieTestProj.framework */; };
 		5B4B74E61BB98A0600197534 /* NessieFmwk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8C549F11ACEE595002206AC /* NessieFmwk.framework */; };
 		5B4B74E71BB98A0600197534 /* NessieFmwk.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B8C549F11ACEE595002206AC /* NessieFmwk.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -33,7 +35,6 @@
 		B85401A41B0A895400031001 /* Deposit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85401A31B0A895400031001 /* Deposit.swift */; };
 		B85401A61B0AE49500031001 /* Withdrawal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85401A51B0AE49500031001 /* Withdrawal.swift */; };
 		B86E4A7D1B0BD3C00076A6D0 /* EnterpriseRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E4A7C1B0BD3C00076A6D0 /* EnterpriseRequests.swift */; };
-		B86E4A7F1B0BD6EF0076A6D0 /* NSEFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E4A7E1B0BD6EF0076A6D0 /* NSEFunctionalTests.swift */; };
 		B8C549F71ACEE595002206AC /* Nessie-iOS-Wrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = B8C549F61ACEE595002206AC /* Nessie-iOS-Wrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B8C549FD1ACEE595002206AC /* NessieFmwk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8C549F11ACEE595002206AC /* NessieFmwk.framework */; };
 		B8C54A041ACEE595002206AC /* Nessie_iOS_WrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C54A031ACEE595002206AC /* Nessie_iOS_WrapperTests.swift */; };
@@ -81,6 +82,7 @@
 /* Begin PBXFileReference section */
 		047FB39A476B2A2254D31988 /* Pods_Nessie_iOS_WrapperTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Nessie_iOS_WrapperTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B2925DC23D67A8B0304782E /* Pods-Nessie-iOS-Wrapper.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Nessie-iOS-Wrapper.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Nessie-iOS-Wrapper/Pods-Nessie-iOS-Wrapper.debug.xcconfig"; sourceTree = "<group>"; };
+		1F1CF43A1E3FD0E3009059EB /* Loan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Loan.swift; sourceTree = "<group>"; };
 		3F65ECC0F92AFCC5AD4C4089 /* Pods-Nessie-iOS-Wrapper.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Nessie-iOS-Wrapper.release.xcconfig"; path = "Pods/Target Support Files/Pods-Nessie-iOS-Wrapper/Pods-Nessie-iOS-Wrapper.release.xcconfig"; sourceTree = "<group>"; };
 		44A1DB88D89CE0CE951B7CC9 /* Pods_NessieTestProjTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NessieTestProjTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		48FAB78D804C8A747637B6E3 /* Pods-NessieTestProjTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NessieTestProjTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-NessieTestProjTests/Pods-NessieTestProjTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 				B8411CB11AF97C4000047389 /* Branch.swift */,
 				B81D5BC21B0A87470086B2C6 /* Customer.swift */,
 				B85401A31B0A895400031001 /* Deposit.swift */,
+				1F1CF43A1E3FD0E3009059EB /* Loan.swift */,
 				5BF9F35D1B98A90E000D2D4D /* Purchase.swift */,
 				5BF9F35B1B98A902000D2D4D /* Transfer.swift */,
 				B85401A51B0AE49500031001 /* Withdrawal.swift */,
@@ -659,9 +662,9 @@
 			files = (
 				5BF0FEA01D8C675700223ED4 /* TabViewController.swift in Sources */,
 				B834EB151AE5BB5000379E11 /* ViewController.swift in Sources */,
+				1F1CF43E1E3FD8F7009059EB /* NSEFunctionalTests.swift in Sources */,
 				B834EB131AE5BB5000379E11 /* AppDelegate.swift in Sources */,
 				5BF0FEA21D8C676900223ED4 /* SecondViewController.swift in Sources */,
-				B86E4A7F1B0BD6EF0076A6D0 /* NSEFunctionalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -680,6 +683,7 @@
 				B85401A61B0AE49500031001 /* Withdrawal.swift in Sources */,
 				B8C54A0E1ACEE5A6002206AC /* NSEClient.swift in Sources */,
 				B8411CAC1AF9706B00047389 /* ATM.swift in Sources */,
+				1F1CF43B1E3FD0E3009059EB /* Loan.swift in Sources */,
 				B85401A41B0A895400031001 /* Deposit.swift in Sources */,
 				B81D5BC31B0A87470086B2C6 /* Customer.swift in Sources */,
 				5BF9F35E1B98A90E000D2D4D /* Purchase.swift in Sources */,
@@ -755,7 +759,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Nessie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -769,7 +773,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Nessie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -852,7 +856,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -895,7 +899,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -924,7 +928,7 @@
 				PRODUCT_NAME = NessieFmwk;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -945,7 +949,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Nessie.NessieFmwk;
 				PRODUCT_NAME = NessieFmwk;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Nessie-iOS-Wrapper/Loan.swift
+++ b/Nessie-iOS-Wrapper/Loan.swift
@@ -119,13 +119,7 @@ open class LoanRequest {
                                                "credit_score": newLoan.creditScore,
                                                "monthly_payment": newLoan.monthlyPayment,
                                                "amount": newLoan.amount]
-        
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-dd-MM"
-        if let creationDate = newLoan.creationDate as Date? {
-            params["creationDate"] = dateFormatter.string(from: creationDate)
-        }
-        
+
         if let description = newLoan.description {
             params["description"] = description
         }

--- a/Nessie-iOS-Wrapper/Loan.swift
+++ b/Nessie-iOS-Wrapper/Loan.swift
@@ -1,0 +1,200 @@
+//
+//  Loan.swift
+//  Nessie-iOS-Wrapper
+//
+//  Created by Ji,Jason on 1/30/17.
+//  Copyright © 2017 Nessie. All rights reserved.
+//
+
+import Foundation
+import SwiftyJSON
+
+public enum LoanType: String {
+    case auto, home, smallBusiness="small business", unknown
+}
+
+public enum LoanStatus: String {
+    case pending, approved, declined, unknown
+}
+
+open class Loan: JsonParser {
+    open var loanId: String
+    open var type: LoanType
+    open var status: LoanStatus
+    open var creditScore: Int
+    open var monthlyPayment: Double
+    open var amount: Int
+    open var creationDate: Date?
+    open var description: String?
+    
+    public init(loanId: String, type: LoanType, status: LoanStatus, creditScore: Int, monthlyPayment: Double, amount: Int, creationDate: Date?, description: String?) {
+        self.loanId = loanId
+        self.type = type
+        self.status = status
+        self.creditScore = creditScore
+        self.monthlyPayment = monthlyPayment
+        self.amount = amount
+        self.creationDate = creationDate
+        self.description = description
+    }
+    
+    public required init(data: JSON) {
+        self.loanId = data["_id"].string ?? ""
+        self.type = LoanType(rawValue: data["type"].string ?? "") ?? .unknown
+        self.status = LoanStatus(rawValue: data["status"].string ?? "") ?? .unknown
+        self.creditScore = data["credit_score"].int ?? 0
+        self.monthlyPayment = data["monthly_payment"].double ?? 0
+        self.amount = data["amount"].int ?? 0
+        self.creationDate = data["creation_date"].string?.stringToDate()
+        self.description = data["description"].string
+    }
+}
+
+open class LoanRequest {
+    fileprivate var requestType: HTTPType!
+    fileprivate var accountId: String?
+    fileprivate var loanId: String?
+    
+    public init () {}
+    
+    fileprivate func buildRequestUrl() -> String {
+        
+        var requestString = "\(baseString)/loans/"
+        if let accountId = accountId {
+            requestString = "\(baseString)/accounts/\(accountId)/loans"
+        }
+        
+        if let loanId = loanId {
+            requestString += "\(loanId)"
+        }
+        
+        requestString += "?key=\(NSEClient.sharedInstance.getKey())"
+        
+        return requestString
+    }
+    
+    // APIs
+    open func getLoan(_ loanId: String, completion: @escaping (_ loan: Loan?, _ error: NSError?) -> Void) {
+        requestType = HTTPType.GET
+        self.loanId = loanId
+        
+        let nseClient = NSEClient.sharedInstance
+        let request = nseClient.makeRequest(buildRequestUrl(), requestType: requestType)
+        nseClient.loadDataFromURL(request, completion: {(data, error) -> Void in
+            if (error != nil) {
+                completion(nil, error)
+            } else {
+                let json = JSON(data: data!)
+                let response = BaseResponse<Loan>(data: json)
+                completion(response.object, nil)
+            }
+        })
+    }
+    
+    open func getLoansFromAccountId(_ accountId: String, completion: @escaping (_ loanArrays: Array<Loan>?, _ error: NSError?) -> Void) {
+        requestType = HTTPType.GET
+        self.accountId = accountId
+        
+        let nseClient = NSEClient.sharedInstance
+        let request = nseClient.makeRequest(buildRequestUrl(), requestType: requestType)
+        nseClient.loadDataFromURL(request, completion: {(data, error) -> Void in
+            if (error != nil) {
+                completion(nil, error)
+            } else {
+                let json = JSON(data: data!)
+                let response = BaseResponse<Loan>(data: json)
+                completion(response.requestArray, nil)
+            }
+        })
+    }
+    
+    open func postLoan(_ newLoan: Loan, accountId: String, completion: @escaping (_ loanResponse: BaseResponse<Loan>?, _ error: NSError?) -> Void) {
+        requestType = HTTPType.POST
+        self.accountId = accountId
+        let nseClient = NSEClient.sharedInstance
+        let request = nseClient.makeRequest(buildRequestUrl(), requestType: self.requestType)
+        
+        var params: Dictionary<String, Any> = ["type": newLoan.type.rawValue,
+                                               "status": newLoan.status.rawValue,
+                                               "credit_score": newLoan.creditScore,
+                                               "monthly_payment": newLoan.monthlyPayment,
+                                               "amount": newLoan.amount]
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-dd-MM"
+        if let creationDate = newLoan.creationDate as Date? {
+            params["creationDate"] = dateFormatter.string(from: creationDate)
+        }
+        
+        if let description = newLoan.description {
+            params["description"] = description
+        }
+        
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: params, options: [])
+        } catch let error as NSError {
+            request.httpBody = nil
+            completion(nil, error)
+        }
+        
+        nseClient.loadDataFromURL(request, completion: {(data, error) -> Void in
+            if (error != nil) {
+                completion(nil, error)
+            } else {
+                let json = JSON(data: data!)
+                let response = BaseResponse<Loan>(data: json)
+                completion(response, nil)
+            }
+        })
+    }
+    
+    open func putLoan(_ updatedLoan: Loan, completion: @escaping (_ loanResponse: BaseResponse<Loan>?, _ error: NSError?) -> Void) {
+        requestType = HTTPType.PUT
+        loanId = updatedLoan.loanId
+        let nseClient = NSEClient.sharedInstance
+        let request = nseClient.makeRequest(buildRequestUrl(), requestType: self.requestType)
+        
+        var params: Dictionary<String, Any> = ["type": updatedLoan.type.rawValue,
+                                               "status": updatedLoan.status.rawValue,
+                                               "credit_score": updatedLoan.creditScore,
+                                               "monthly_payment": updatedLoan.monthlyPayment,
+                                               "amount": updatedLoan.amount]
+        
+        if let description = updatedLoan.description {
+            params["description"] = description
+        }
+        
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: params, options: [])
+        } catch let error as NSError {
+            request.httpBody = nil
+            completion(nil, error)
+        }
+        
+        nseClient.loadDataFromURL(request, completion: {(data, error) -> Void in
+            if (error != nil) {
+                completion(nil, error)
+            } else {
+                let json = JSON(data: data!)
+                let response = BaseResponse<Loan>(data: json)
+                completion(response, nil)
+            }
+        })
+    }
+    
+    open func deleteLoan(_ loanId: String, completion: @escaping (_ loanResponse: BaseResponse<Loan>?, _ error: NSError?) -> Void) {
+        requestType = HTTPType.DELETE
+        self.loanId = loanId
+        
+        let nseClient = NSEClient.sharedInstance
+        let request = nseClient.makeRequest(buildRequestUrl(), requestType: self.requestType)
+        nseClient.loadDataFromURL(request, completion: {(data, error) -> Void in
+            if (error != nil) {
+                completion(nil, error)
+            } else {
+                let response = BaseResponse<Loan>(requestArray: nil, object: nil, message: "Loan deleted")
+                completion(response, nil)
+            }
+        })
+    }
+}

--- a/NessieTestProj/Base.lproj/Main.storyboard
+++ b/NessieTestProj/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ygc-OV-HSg">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ygc-OV-HSg">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -130,122 +130,99 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nn1-di-Kwj">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Wf6-3q-cw7">
+                                <rect key="frame" x="114" y="92.5" width="146" height="482.5"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZBS-wY-9QL">
-                                        <rect key="frame" x="172" y="125.5" width="31" height="30"/>
-                                        <state key="normal" title="ATM"/>
-                                        <connections>
-                                            <action selector="testAtmRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="u8I-qY-GgU"/>
-                                        </connections>
-                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customer requests" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aX6-gR-heL">
+                                        <rect key="frame" x="0.0" y="0.0" width="146" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2Ei-TP-IT2">
-                                        <rect key="frame" x="155" y="75.5" width="65" height="30"/>
+                                        <rect key="frame" x="40.5" y="32.5" width="65" height="30"/>
                                         <state key="normal" title="Accounts"/>
                                         <connections>
                                             <action selector="testAccountsRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="FJq-hx-RgQ"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZBS-wY-9QL">
+                                        <rect key="frame" x="57.5" y="74.5" width="31" height="30"/>
+                                        <state key="normal" title="ATM"/>
+                                        <connections>
+                                            <action selector="testAtmRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="u8I-qY-GgU"/>
+                                        </connections>
+                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3X2-eY-jzw">
-                                        <rect key="frame" x="172.5" y="175.5" width="30" height="30"/>
+                                        <rect key="frame" x="58" y="116.5" width="30" height="30"/>
                                         <state key="normal" title="Bills"/>
                                         <connections>
                                             <action selector="testBillRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="IGG-sI-sGd"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qtn-qt-YTV">
-                                        <rect key="frame" x="155" y="232.5" width="65" height="30"/>
+                                        <rect key="frame" x="40.5" y="158.5" width="65" height="30"/>
                                         <state key="normal" title="Branches"/>
                                         <connections>
                                             <action selector="testBranchesRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="VPx-0n-Y47"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KwH-Bm-Pos">
-                                        <rect key="frame" x="150" y="284.5" width="75" height="30"/>
+                                        <rect key="frame" x="35.5" y="200.5" width="75" height="30"/>
                                         <state key="normal" title="Customers"/>
                                         <connections>
                                             <action selector="testCustomersRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="NGw-dv-075"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LrF-01-76p" userLabel="Loans">
+                                        <rect key="frame" x="52.5" y="242.5" width="41" height="30"/>
+                                        <state key="normal" title="Loans"/>
+                                        <connections>
+                                            <action selector="testLoanRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="Ilp-30-7Fn"/>
+                                        </connections>
+                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z20-Cm-cG3">
-                                        <rect key="frame" x="157" y="337.5" width="61" height="30"/>
+                                        <rect key="frame" x="42.5" y="284.5" width="61" height="30"/>
                                         <state key="normal" title="Deposits"/>
                                         <connections>
                                             <action selector="testDepositsRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="KwJ-5h-lBc"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HLS-fd-Gzv">
-                                        <rect key="frame" x="151.5" y="393.5" width="72" height="30"/>
+                                        <rect key="frame" x="37" y="326.5" width="72" height="30"/>
                                         <state key="normal" title="Purchases"/>
                                         <connections>
                                             <action selector="testPurchasesRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="mLg-X0-1R8"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zgw-4t-fFJ">
-                                        <rect key="frame" x="151" y="448.5" width="73" height="30"/>
+                                        <rect key="frame" x="36.5" y="368.5" width="73" height="30"/>
                                         <state key="normal" title="Merchants"/>
                                         <connections>
                                             <action selector="testMerchantsRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="yZg-Gi-cEs"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cUn-bh-em2">
-                                        <rect key="frame" x="155" y="500.5" width="65" height="30"/>
+                                        <rect key="frame" x="40.5" y="410.5" width="65" height="30"/>
                                         <state key="normal" title="Transfers"/>
                                         <connections>
                                             <action selector="testTransfersRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="mBl-Md-88M"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Ik-8m-12D">
-                                        <rect key="frame" x="145" y="551.5" width="85" height="30"/>
+                                        <rect key="frame" x="30.5" y="452.5" width="85" height="30"/>
                                         <state key="normal" title="Withdrawals"/>
                                         <connections>
                                             <action selector="testWithdrawalsRequestsWithSender:" destination="oji-8n-gkc" eventType="touchUpInside" id="rMy-gN-N2t"/>
                                         </connections>
                                     </button>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customer requests" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aX6-gR-heL">
-                                        <rect key="frame" x="0.0" y="22" width="375" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="cUn-bh-em2" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="0SL-Qh-qPt"/>
-                                    <constraint firstItem="HLS-fd-Gzv" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="0bU-IA-zio"/>
-                                    <constraint firstItem="KwH-Bm-Pos" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="2tP-Xe-26r"/>
-                                    <constraint firstAttribute="bottom" secondItem="6Ik-8m-12D" secondAttribute="bottom" constant="65" id="4OX-ol-z7I"/>
-                                    <constraint firstItem="ZBS-wY-9QL" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="9V4-sq-Kxt"/>
-                                    <constraint firstAttribute="trailing" secondItem="aX6-gR-heL" secondAttribute="trailing" id="9dU-wb-NdO"/>
-                                    <constraint firstItem="aX6-gR-heL" firstAttribute="leading" secondItem="nn1-di-Kwj" secondAttribute="leading" id="ClG-m7-cbJ"/>
-                                    <constraint firstItem="2Ei-TP-IT2" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="JB3-JO-aGt"/>
-                                    <constraint firstItem="Z20-Cm-cG3" firstAttribute="top" secondItem="KwH-Bm-Pos" secondAttribute="bottom" constant="23" id="Mk8-EV-6cs"/>
-                                    <constraint firstItem="qtn-qt-YTV" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="R6K-Ft-63t"/>
-                                    <constraint firstItem="Z20-Cm-cG3" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="RZ7-dW-zzS"/>
-                                    <constraint firstItem="6Ik-8m-12D" firstAttribute="top" secondItem="cUn-bh-em2" secondAttribute="bottom" constant="21" id="TNS-vu-f8b"/>
-                                    <constraint firstItem="aX6-gR-heL" firstAttribute="top" secondItem="nn1-di-Kwj" secondAttribute="top" constant="22" id="UPc-Nq-LhF"/>
-                                    <constraint firstItem="ZBS-wY-9QL" firstAttribute="top" secondItem="2Ei-TP-IT2" secondAttribute="bottom" constant="20" id="YDb-PL-MN4"/>
-                                    <constraint firstItem="cUn-bh-em2" firstAttribute="top" secondItem="zgw-4t-fFJ" secondAttribute="bottom" constant="22" id="YbS-cb-SEy"/>
-                                    <constraint firstItem="3X2-eY-jzw" firstAttribute="top" secondItem="ZBS-wY-9QL" secondAttribute="bottom" constant="20" id="Zui-bR-Bye"/>
-                                    <constraint firstItem="6Ik-8m-12D" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="bhr-f9-Ymi"/>
-                                    <constraint firstItem="zgw-4t-fFJ" firstAttribute="top" secondItem="HLS-fd-Gzv" secondAttribute="bottom" constant="25" id="j8G-mE-Hmf"/>
-                                    <constraint firstItem="KwH-Bm-Pos" firstAttribute="top" secondItem="qtn-qt-YTV" secondAttribute="bottom" constant="22" id="n4E-Dn-CXm"/>
-                                    <constraint firstItem="zgw-4t-fFJ" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="nUd-NI-4Cr"/>
-                                    <constraint firstItem="aX6-gR-heL" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="oSW-Tj-8sa"/>
-                                    <constraint firstItem="qtn-qt-YTV" firstAttribute="top" secondItem="3X2-eY-jzw" secondAttribute="bottom" constant="27" id="ppY-hB-jsQ"/>
-                                    <constraint firstItem="2Ei-TP-IT2" firstAttribute="top" secondItem="aX6-gR-heL" secondAttribute="bottom" constant="33" id="pyM-VS-PIl"/>
-                                    <constraint firstItem="3X2-eY-jzw" firstAttribute="centerX" secondItem="nn1-di-Kwj" secondAttribute="centerX" id="tmq-mq-LEY"/>
-                                    <constraint firstItem="HLS-fd-Gzv" firstAttribute="top" secondItem="Z20-Cm-cG3" secondAttribute="bottom" constant="26" id="v1M-Gv-dQy"/>
-                                </constraints>
-                            </scrollView>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="nn1-di-Kwj" firstAttribute="width" secondItem="TVO-EN-q8N" secondAttribute="width" id="BqT-ui-46Y"/>
-                            <constraint firstItem="nn1-di-Kwj" firstAttribute="leading" secondItem="TVO-EN-q8N" secondAttribute="leading" id="VS2-gX-UjI"/>
-                            <constraint firstAttribute="trailing" secondItem="nn1-di-Kwj" secondAttribute="trailing" id="aHe-sU-YdJ"/>
-                            <constraint firstItem="Lk3-5n-zzT" firstAttribute="top" secondItem="nn1-di-Kwj" secondAttribute="bottom" id="nTn-g5-U1S"/>
-                            <constraint firstItem="nn1-di-Kwj" firstAttribute="top" secondItem="TVO-EN-q8N" secondAttribute="top" id="sq5-Xw-3Cc"/>
+                            <constraint firstItem="Wf6-3q-cw7" firstAttribute="centerX" secondItem="TVO-EN-q8N" secondAttribute="centerX" id="0oC-wW-nns"/>
+                            <constraint firstItem="Wf6-3q-cw7" firstAttribute="centerY" secondItem="TVO-EN-q8N" secondAttribute="centerY" id="5ae-7a-TaD"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Customer Requests" id="EyK-3P-cQI"/>

--- a/NessieTestProj/NSEFunctionalTests.swift
+++ b/NessieTestProj/NSEFunctionalTests.swift
@@ -469,6 +469,41 @@ class DepositsTests {
     }
 }
 
+class LoanTests {
+    let client = NSEClient.sharedInstance
+    
+    init() {
+        client.setKey("bca7093ce9c023bb642d0734b29f1ad2")
+        
+        testGetAllLoansFromAccount()
+    }
+    
+    func testGetAllLoansFromAccount() {
+        let account: Account = Account(accountId: "57d32a5ce63c5995587e85ec",
+                                       accountType:.CreditCard,
+                                       nickname: "Hola",
+                                       rewards: 10,
+                                       balance: 100,
+                                       accountNumber: "1234567890123456",
+                                       customerId: "57d0c20d1fd43e204dd48282")
+        AccountRequest().postAccount(account) { (response, error) in
+            let loan = Loan(loanId: "abcd1234", type: .home, status: .approved, creditScore: 800, monthlyPayment: 50, amount: 100, creationDate: Date(), description: "A home loan for the ages")
+            LoanRequest().postLoan(loan, accountId: "57d32a5ce63c5995587e85ec", completion: { (loanResponse, error) in
+                if let error = error {
+                    print(error)
+                }
+                else {
+                    let loanResponse = loanResponse as BaseResponse<Loan>?
+                    let message = loanResponse?.message
+                    let loanCreated = loanResponse?.object
+                    print("\(message): \(loanCreated)")
+                }
+            })
+        }
+        
+    }
+}
+
 class PurchasesTests {
     let client = NSEClient.sharedInstance
     

--- a/NessieTestProj/ViewController.swift
+++ b/NessieTestProj/ViewController.swift
@@ -52,5 +52,7 @@ class ViewController: UIViewController {
     @IBAction func testWithdrawalsRequests(sender: UIButton) {
         let _ = WithdrawalsTests()
     }
-    
+    @IBAction func testLoanRequests(sender: UIButton) {
+        let _ = LoanTests()
+    }
 }


### PR DESCRIPTION
I've updated the SDK to support the Loans endpoint. Get loans by accountId, get loan by loanId, create loan, update loan, delete loan.

Also, the view controller used as the test harness is now a stack view with all the buttons, rather than a scroll view with manually-created constraints for all the buttons - hope that's cool. Was easier than inserting my button. Consequently, the project now requires iOS 9.0+, which seems 100% fine for a hackathon.